### PR TITLE
Modernize homepage button styling

### DIFF
--- a/src/components/NavigationButtons.astro
+++ b/src/components/NavigationButtons.astro
@@ -39,7 +39,7 @@ const sections = [
         font-weight: 600;
         text-decoration: none;
         color: #ffffff;
-        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        background: linear-gradient(135deg, #1e6c93 0%, #136363 100%);
         border-radius: 12px;
         box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.08);
         transition: all 0.3s ease;
@@ -50,7 +50,7 @@ const sections = [
     a:hover {
         transform: translateY(-2px);
         box-shadow: 0 7px 14px rgba(0, 0, 0, 0.15), 0 3px 6px rgba(0, 0, 0, 0.1);
-        background: linear-gradient(135deg, #764ba2 0%, #667eea 100%);
+        background: linear-gradient(135deg, #136363 0%, #1e6c93 100%);
     }
 
     a:active {


### PR DESCRIPTION
Old
<img width="1156" height="185" alt="image" src="https://github.com/user-attachments/assets/60565eac-d8e1-4c63-b5a7-bcec9cbc19e3" />


New (and they move slightly when you hover over them)
<img width="1236" height="225" alt="image" src="https://github.com/user-attachments/assets/3a9eb532-40b0-4ec8-82d7-c32821d85fb0" />
