### PR TITLE
Add events navigation

### DIFF
--- a/src/pages/events.astro
+++ b/src/pages/events.astro
@@ -2,7 +2,14 @@
 import { getCollection, render } from "astro:content";
 import MainLayout from "../layouts/Main.astro";
 
-const events = await getCollection("events")
+const eventsUnsorted = await getCollection("events")
+
+// Sort events by date (earliest first)
+const events = eventsUnsorted.sort((a, b) => {
+    const dateA = new Date(a.data.date);
+    const dateB = new Date(b.data.date);
+    return dateA.getTime() - dateB.getTime();
+});
 
 // Function to create a URL-friendly ID from the event title
 function createEventId(title: string): string {


### PR DESCRIPTION
Adds a "quick navigation" bar at the top that links to each workshop / event in chronological order