### PR TITLE
Conditionally format past vs upcoming events

### DIFF
--- a/src/pages/events.astro
+++ b/src/pages/events.astro
@@ -20,6 +20,15 @@ function createEventId(title: string): string {
         .trim();
 }
 
+// Function to check if an event date is in the past
+function isPastEvent(dateString: string): boolean {
+    const eventDate = new Date(dateString);
+    const today = new Date();
+    // Set today to start of day for fair comparison
+    today.setHours(0, 0, 0, 0);
+    return eventDate < today;
+}
+
 ---
 
 <MainLayout frontmatter={{ title: "Events" }}>
@@ -40,15 +49,16 @@ function createEventId(title: string): string {
     {events.map(async entry => {
         const { Content } = await render(entry)
         const eventId = createEventId(entry.data.title);
+        const isPast = isPastEvent(entry.data.date);
 
         return (
-        <section id={eventId} class="event-section">
+        <section id={eventId} class={`event-section ${isPast ? 'past-event' : 'upcoming-event'}`}>
             <h2>{entry.data.title}</h2>
-            <p><strong>Day: </strong>{entry.data.date}</p>
-            <p><strong>Time: </strong>{entry.data.time}</p>
-            <p><strong>Location: </strong>{entry.data.location}</p>
+            {!isPast && <p><strong>Day: </strong>{entry.data.date}</p>}
+            {!isPast && <p><strong>Time: </strong>{entry.data.time}</p>}
+            {!isPast && <p><strong>Location: </strong>{entry.data.location}</p>}
             <p><strong>Topic: </strong>{entry.data.topic}</p>
-            <p><strong>Sign up for this event <a href={entry.data.signup}>here</a></strong></p>
+            {!isPast && <p><strong>Sign up for this event <a href={entry.data.signup}>here</a></strong></p>}
             <Content />
         </section>
         )


### PR DESCRIPTION
## Summary
- Added date-based conditional formatting for events on the Events page
- Past events (date before today) now display reduced information: only Title, Topic, and Content
- Upcoming events continue to show full details: Day, Time, Location, Topic, Sign up, and Content
- Added CSS classes `past-event` and `upcoming-event` for potential future styling

## Test plan
- [x] Verified dev server runs without errors
- [x] Confirmed past events (January 15, 2025 and March 19, 2025 workshops) hide Day, Time, Location, and Sign up fields
- [x] Test with a future-dated event to verify full information displays
- [x] Review the Events page at http://localhost:4321/events/ after running `npm run dev`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)