### PR TITLE
fix: move FAQ into Resources column in footer

### DIFF
--- a/src/layouts/Footer.astro
+++ b/src/layouts/Footer.astro
@@ -13,23 +13,19 @@ const flatItems    = navItems.filter(item => item.path && item.path !== "/")
             <a href="mailto:info@zappfish.org">info@zappfish.org</a>
         </div>
 
-        {groupedItems.map(item => (
+        {groupedItems.map((item, i) => (
             <nav class="footer-col" aria-label={`${item.label} navigation`}>
                 <ul class="footer-link-list">
                     {item.children!.map(child => (
                         <li><a href={child.path}>{child.label}</a></li>
                     ))}
+                    {i === groupedItems.length - 1 && flatItems.map(item => (
+                        <li><a href={item.path}>{item.label}</a></li>
+                    ))}
                 </ul>
             </nav>
         ))}
 
-        <nav class="footer-col" aria-label="Resources navigation">
-            <ul class="footer-link-list">
-                {flatItems.map(item => (
-                    <li><a href={item.path}>{item.label}</a></li>
-                ))}
-            </ul>
-        </nav>
 
     </div>
 


### PR DESCRIPTION
## Summary

- FAQ was floating alone on the left side of the footer as an orphaned row
- Moved FAQ into the bottom of the Resources column so the footer grid stays balanced

## Test plan

- [ ] Verify FAQ appears in the Resources column in the footer
- [ ] Check footer layout on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)