### PR TITLE
Add Governance links across site (#73)

### DIFF
--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -6,9 +6,10 @@ export type NavItem =
 export const navItems: NavItem[] = [
     { label: "Home",        path: "/" },
     { label: "About",       children: [
-        { label: "Goals",   path: "/goals" },
-        { label: "SAB",     path: "/sab" },
-        { label: "Team",    path: "/team" },
+        { label: "Goals",       path: "/goals" },
+        { label: "Governance",  path: "/ZAPPGovernance" },
+        { label: "SAB",         path: "/sab" },
+        { label: "Team",        path: "/team" },
     ]},
     { label: "Get Involved", children: [
         { label: "Community",   path: "/community" },

--- a/src/pages/community.astro
+++ b/src/pages/community.astro
@@ -32,7 +32,7 @@ import IconDatabase from '../components/icons/IconDatabase.astro'
     </section>
 
     <section class="action-cards">
-        <ActionCard title="Governance" description="Coming Soon" href="#" comingSoon>
+        <ActionCard title="Governance" description="Documents, policies, and contribution guidelines" href="/ZAPPGovernance" linkLabel="View Governance">
             <IconShield slot="icon" />
         </ActionCard>
         <ActionCard title="Submit Data" description="Coming Soon" href="#" comingSoon>

--- a/src/pages/faqs.astro
+++ b/src/pages/faqs.astro
@@ -4,6 +4,7 @@ import Hero from '../layouts/Hero.astro'
 import IconMail from '../components/icons/IconMail.astro'
 import IconStar from '../components/icons/IconStar.astro'
 import IconTarget from '../components/icons/IconTarget.astro'
+import IconShield from '../components/icons/IconShield.astro'
 import { faqs, CATEGORIES } from '../data/faqs'
 import Accordion from '../components/ui/Accordion.astro'
 
@@ -60,6 +61,12 @@ const categories = ['All', ...CATEGORIES]
                         <a href="/get-involved" class="quick-link">
                             <span class="quick-link-icon"><IconStar /></span>
                             Join Community
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/ZAPPGovernance" class="quick-link">
+                            <span class="quick-link-icon"><IconShield /></span>
+                            Governance
                         </a>
                     </li>
                 </ul>


### PR DESCRIPTION
## Summary
- Replace "Coming Soon" Governance card on Community page with a working link to `/ZAPPGovernance`
- Add Governance to the About dropdown, between Goals and SAB
- Add Governance to the FAQs Quick Links sidebar (with shield icon)

Closes #73

## Test plan
- [ ] Verify Governance card on `/community` links to `/ZAPPGovernance`
- [ ] Verify About dropdown shows Governance between Goals and SAB
- [ ] Verify Governance link appears in FAQs sidebar under Quick Links
- [ ] Confirm `/ZAPPGovernance` resolves correctly on the deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)