### PR TITLE
Update Technical Resources links (#85)

### DIFF
--- a/src/pages/resources.astro
+++ b/src/pages/resources.astro
@@ -46,15 +46,15 @@ const resources: ResourceGroup[] = [
             },
             {
                 title: 'ZAPP Toxicophenotype Data Model',
-                description: 'Repository for the zebrafish toxicology atlas schema — data model, code, and issues.',
-                href: 'https://github.com/zappfish/zebrafish-toxicology-atlas-schema',
+                description: 'Repository folder for the zebrafish toxicology atlas schema — data model and code',
+                href: 'https://github.com/zappfish/zapp-atlas/tree/main/server/src/zapp_atlas/schema',
                 label: 'View Repository',
                 icon: CodeIcon,
             },
             {
                 title: 'ZAPP LinkML Schema Diagram',
                 description: 'Interactive entity-relationship diagram of the zebrafish toxicophenotype schema, built with LinkML.',
-                href: 'https://zappfish.org/zebrafish-toxicology-atlas-schema/schema_diagram/',
+                href: 'https://zappfish.org/ZAPPSchema/schema_diagram/',
                 label: 'View Diagram',
                 icon: ShareIcon,
             },


### PR DESCRIPTION
Updates the Technical Resources page (https://zappfish.org/resources/) per #85.

## Changes
- **ZAPP Toxicophenotype Data Model**
  - Link → `https://github.com/zappfish/zapp-atlas/tree/main/server/src/zapp_atlas/schema`
  - Subheading → "Repository folder for the zebrafish toxicology atlas schema — data model and code"
- **ZAPP LinkML Schema Diagram**
  - Link → `https://zappfish.org/ZAPPSchema/schema_diagram/`

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)